### PR TITLE
Change Heroku tier from free to basic

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,11 +44,11 @@
     "formation": {
       "web": {
         "quantity": 1,
-        "size": "free"
+        "size": "basic"
       },
       "worker": {
         "quantity": 1,
-        "size": "free"
+        "size": "basic"
       }
     },
     "addons": [


### PR DESCRIPTION
Deploy to Heroku fails because Heroku has deprecated the free tier. This will default to basic.